### PR TITLE
Udjusted height

### DIFF
--- a/Assets/Resources/Scripts/Calibration.cs
+++ b/Assets/Resources/Scripts/Calibration.cs
@@ -8,11 +8,14 @@ public class Calibration : MonoBehaviour {
     public int currentStage = 0; //0 - pos, 1 - leftVerticalMin, 2 - leftVerticalMax
 	public GameObject player;
 	public Transform correctPlayerPos;
-
+    public GameObject playerController;
     public Transform avatar;
     public Transform leftHand;
     public Transform rightHand;
 
+
+    public float heightInFeet = 6.0f;
+    public bool sitting = false;
 
     public GameObject cubeHolder;
     public Transform sphere;
@@ -28,8 +31,13 @@ public class Calibration : MonoBehaviour {
 	void Start () 
 	{
 		tv.text = "Please stand on the blue square on the ground. (Press the trigger to <continue>)";
-        
-        
+        float meters = getMeters(heightInFeet);
+        if (sitting)
+        {
+            meters /= 1.3f;
+        }
+        Debug.Log(playerController.transform.position.y + "; " + meters);
+        playerController.transform.position = new Vector3(playerController.transform.position.x, meters, playerController.transform.position.z);
     }
   	
     
@@ -47,9 +55,11 @@ public class Calibration : MonoBehaviour {
                     if (getDistance(player.transform, correctPlayerPos) <= 0.2 && getDistance(player.transform, correctPlayerPos) >= -0.2)
                     {
                         
+                        
+
                         tv.text = "Next we will check the bounds for your left hand. Start by putting your LEFT hand inside the box.";
                         Instantiate(cubeHolder, leftCubeSpot.transform.position, Quaternion.identity);
-                       
+                        
                         foreach (GameObject cube in cubes)
                         {
 							cube.gameObject.SetActive (false);
@@ -99,6 +109,10 @@ public class Calibration : MonoBehaviour {
        
     }
 
+    float getMeters(float feet)
+    {
+        return feet * 0.3048f;
+    }
 
 	float getDistance(Transform x1, Transform x2)
 	{

--- a/Assets/Scenes/CalibrationScene.unity
+++ b/Assets/Scenes/CalibrationScene.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 8
+  serializedVersion: 9
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -39,6 +39,7 @@ RenderSettings:
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
   m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -54,11 +55,10 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 9
+    serializedVersion: 10
     m_Resolution: 2
     m_BakeResolution: 10
-    m_TextureWidth: 1024
-    m_TextureHeight: 1024
+    m_AtlasSize: 1024
     m_AO: 0
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
@@ -216,6 +216,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: d9ed81d4fbf959a468e53f1553e4cb45, type: 2}
   m_StaticBatchInfo:
@@ -313,6 +314,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -695,6 +697,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -1185,9 +1188,12 @@ MonoBehaviour:
   currentStage: 0
   player: {fileID: 1467102614}
   correctPlayerPos: {fileID: 1977902787}
+  playerController: {fileID: 706678280}
   avatar: {fileID: 1491201140}
   leftHand: {fileID: 1878207973}
   rightHand: {fileID: 610377182}
+  heightInFeet: 6
+  sitting: 0
   cubeHolder: {fileID: 1551719784960988, guid: 0318695cf6ca3bc4ea8cfd81507bd17d, type: 2}
   sphere: {fileID: 4828329804621758, guid: 0318695cf6ca3bc4ea8cfd81507bd17d, type: 2}
   leftCubeSpot: {fileID: 845621317}
@@ -1389,6 +1395,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -1557,6 +1564,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -2036,54 +2044,69 @@ AudioSource:
   rolloffCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
-    - serializedVersion: 2
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
       time: 1
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
   panLevelCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
   spreadCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
   reverbZoneMixCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - serializedVersion: 2
+    - serializedVersion: 3
       time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
@@ -2391,6 +2414,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:


### PR DESCRIPTION
Created two variables: heightInFeet and sitting (might remove). Depending on the patients height in feet (eg: 6ft) calculates it in meters for unity units and sets the camera height.
If sitting is enabled divides that value by 1.3. However, this might be obsolete since you can just sit down and it will lower the camera automatically.